### PR TITLE
Fix Recording and Performing Action Bug

### DIFF
--- a/app/src/main/java/edu/cmu/hcii/sugilite/automation/Automator.java
+++ b/app/src/main/java/edu/cmu/hcii/sugilite/automation/Automator.java
@@ -516,8 +516,16 @@ public class Automator {
 ////                }
 //                return nodeToAction.performAction(AccessibilityNodeInfo.ACTION_CLICK);
 //            }
+            synchronized (serviceContext){
+                // This block of code is shyncronized over a single object (SugiliteAccessibilityService object)
+                // and check if any other action is performing, if no action is performing, set actionInProgress to
+                // true and perform the action.
+                if (SugiliteAccessibilityService.actionInProgress.get())
+                    return false;
+                SugiliteAccessibilityService.actionInProgress.set(true);
+                return serviceContext.performTap(rect.centerX(),rect.centerY(),0,40);
+            }
 
-            return serviceContext.performTap(rect.centerX(),rect.centerY(),0,40);
 
 
 


### PR DESCRIPTION
- Add a mutex to inform different parts of code whether an action is performing at the moment. It is used to prevent performing the same action multiple times.
- Fix a concurrency bug (invoking turnOnCatOverlay after the gesture dispatch is finished with a shorter delay instead of waiting for long in parallel)